### PR TITLE
remove escapeExpression from add_group - group titles are already escaped

### DIFF
--- a/coffee/lib/select-parser.coffee
+++ b/coffee/lib/select-parser.coffee
@@ -14,7 +14,7 @@ class SelectParser
     @parsed.push
       array_index: group_position
       group: true
-      label: this.escapeExpression(group.label)
+      label: group.label
       children: 0
       disabled: group.disabled
     this.add_option( option, group_position, group.disabled ) for option in group.childNodes
@@ -37,21 +37,6 @@ class SelectParser
           options_index: @options_index
           empty: true
       @options_index += 1
-
-  escapeExpression: (text) ->
-    if not text? or text is false
-      return ""
-    unless /[\&\<\>\"\'\`]/.test(text)
-      return text
-    map =
-      "<": "&lt;"
-      ">": "&gt;"
-      '"': "&quot;"
-      "'": "&#x27;"
-      "`": "&#x60;"
-    unsafe_chars = /&(?!\w+;)|[\<\>\"\'\`]/g
-    text.replace unsafe_chars, (chr) ->
-      map[chr] || "&amp;"
 
   select_to_array: ->
     if not @parsed?

--- a/tests/group_title_format_test.html
+++ b/tests/group_title_format_test.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  <meta charset="UTF-8">
+  <title>Chosen test</title>
+  <link rel="stylesheet" type="text/css" href="../public/chosen.css">
+  <style>
+    body{
+      font-family: Helvetica, Arial, sans-serif;
+      margin: 10vh 10vw;
+    }
+    #test_result{
+      display: block;
+      margin: 2em;
+      padding: 2em;
+    }
+    .pass{
+      background-color: #BDFF97;
+    }
+    .fail{
+      background-color: #FF9797;
+    }
+  </style>
+  <script src="https://unpkg.com/jquery@1.11.0/dist/jquery.js"></script>
+  <script src="../public/chosen.jquery.js"></script>
+</head>
+<body>
+  <pre id="test_result">
+    test running...
+  </pre>
+
+  <select id="select">
+    <optgroup label="A label with a single quote '">
+      <option>option 1</option>
+      <option>option 2</option>
+    </optgroup>
+    <optgroup label="A label with <div onclick='alert()'>attempted xss</div>">
+      <option>option 3</option>
+      <option>option 4</option>
+    </optgroup>
+  </select>
+
+  <script>
+    $("#select").chosen();
+
+    window.setTimeout(function(){
+      $("#select_chosen").trigger("mousedown");
+
+      window.setTimeout(function(){
+        var success = true;
+        var message = "";
+
+        if($(".group-result").first().html() == "A label with a single quote '"){
+          message = message + "single quote label displayed correctly\n";
+        } else {
+          message = message + "single quote label displayed incorrectly!\n";
+          success = false;
+        }
+
+        if($(".group-result").last().html() == "A label with &lt;div onclick='alert()'&gt;attempted xss&lt;/div&gt;"){
+          message = message + "xss label escaped correctly\n";
+        } else {
+          message = message + "xss escaped incorrectly!\n";
+          success = false;
+        }
+
+        success ? $("#test_result").addClass("pass") : $("#test_result").addClass("fail")
+        $("#test_result").html(message);
+      }, 200);
+    }, 200);
+
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Code reviewers

- [x] @johnny-lai

## Summary of issue

Group titles with single quotes are displayed incorrectly. Single quotes were being displayed as `&#x27;`

## Summary of change

Removed escapeExpression function and call in add_group. Group titles are already escaped.

## Testing Approach

Added a simple html test that renders a chosen dropdown and checks html contents of generated options. [(tests/group_title_format_test.html)](https://github.com/coupa/chosen/blob/15c5008c386381a3496f3fbf58d5824cc4ddefcc/tests/group_title_format_test.html) It would be cool to add a proper JS test runner, but I don't want to make this PR too big.
