### PR TITLE
add label attributes to single select input

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -80,6 +80,8 @@ class Chosen extends AbstractChosen
       @search_container = @container.find('li.search-field').first()
       @search_scroller = @container.find('ul.chosen-scopes')
       @selected_item = @container.find('.chosen-single').first()
+      if @search_field
+        @set_label_attributes()
     
     this.set_tab_index()
     this.set_label_behavior()
@@ -740,6 +742,18 @@ class Chosen extends AbstractChosen
 
     return input_field.val(value) if value?
     input_field.val()
+
+  set_label_attributes: () ->
+    associated_select_field = $('select[id="' + $(@container).attr('id').replace('_chosen', '') + '"]')
+    if aria_describedby = associated_select_field.attr('aria-describedby')
+      @search_field.attr 'aria-describedby', aria_describedby
+
+    if aria_labelledby = associated_select_field.attr('aria-labelledby')
+      @search_field.attr 'aria-labelledby', aria_labelledby
+    else if aria_label = associated_select_field.attr('aria-label')
+      @search_field.attr 'aria-label', aria_label
+    else if aria_label = $('label[for="' + associated_select_field.attr('id') + '"]')
+      @search_field.attr 'aria-label', aria_label.text()
 
 tabCallback = (container) ->
   tabbable_element = null


### PR DESCRIPTION
- [x] @johnny-lai 
- [x] @curtismoore 

ticket:
  https://coupadev.atlassian.net/browse/CD-170887

issue:
  The form field does not have an explicit or implicit <label> relationship, nor a title, aria-labelledby, or aria-label attribute

solution:
  1) if aria-labelledby or aria-label defined on select element, copy the same to chosen input field
  2) if ID defined on select element, get the label element that contains for="<select_element_id>" and grab the text content of the label and assign it to the aria-label on the chosen input field
  3) if aria-describedby defined on select element, always copy this to chosen input field, regardless of items 1 or 2 above