### PR TITLE
fix chosen single select screen reader issues

### DIFF
--- a/coffee/lib/abstract-chosen.coffee
+++ b/coffee/lib/abstract-chosen.coffee
@@ -50,8 +50,10 @@ class AbstractChosen
     @results_none_found = @form_field.getAttribute("data-no_results_text") || @options.no_results_text || AbstractChosen.default_no_result_text
     @remove_option_text = @options.remove_option_text || AbstractChosen.default_remove_option_text
     @removed_text = @options.removed_text || AbstractChosen.default_removed_text
-    @default_single_select_input_hint = @options.single_select_input_hint || AbstractChosen.default_single_select_input_hint
     @default_single_select_field_hint = @options.single_select_field_hint || AbstractChosen.default_single_select_field_hint
+    @default_single_select_result_singular_hint = @options.single_select_result_singular_hint || AbstractChosen.default_single_select_result_singular_hint
+    @default_single_select_results_plural_hint = @options.single_select_results_plural_hint || AbstractChosen.default_single_select_results_plural_hint
+    @default_single_select_highlighted_result_hint = @options.single_select_highlighted_result_hint || AbstractChosen.default_single_select_highlighted_result_hint
 
   mouse_enter: -> @mouse_on_container = true
   mouse_leave: -> @mouse_on_container = false
@@ -257,9 +259,20 @@ class AbstractChosen
           this.results_search()
       when 13
         evt.preventDefault()
-        this.result_select(evt) if this.results_showing
+        if this.results_showing
+          if @result_highlight and not @delete_option
+              item = @source.get_item(@result_highlight[0].getAttribute("data-option-array-index"))
+              if not item.is_scope and not @is_multiple
+                if item.text == null or item.text == @default_text
+                  @search_field.attr("aria-label", @input_aria_label);
+                else
+                  @search_field.attr("aria-label", @input_aria_label + ". " + item.text)
+          this.result_select(evt)
       when 27
-        this.results_hide() if @results_showing
+        if @results_showing
+          this.results_hide()
+          if not @is_multiple and @selected_item.find("span").first().text().trim()
+            this.set_text_for_screen_reader(@selected_item.find("span").first().text())
         return true
       when 9, 38, 40, 16, 91, 17
         # don't do anything on these keys
@@ -333,5 +346,6 @@ class AbstractChosen
   @default_remove_option_text: "Remove Option"
   @default_removed_text: "Removed"
   @default_single_select_field_hint = "Use space or down arrow key to open the combobox."
-  @default_single_select_input_hint = "When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures."
-
+  @default_single_select_result_singular_hint = "aria_setsize result is available."
+  @default_single_select_results_plural_hint = "aria_setsize results are available."
+  @default_single_select_highlighted_result_hint = "result_highlight_text. aria_posinset of aria_setsize is highlighted."


### PR DESCRIPTION
- [x] @johnny-lai 
- [x] @curtismoore 

issue:
https://coupadev.atlassian.net/browse/CD-152516
Chosen Plugin - Multiple Fields - Element appears like a combobox but not coded so(single select).

solution:
Use the ARIA design pattern for a combobox.

1.  input was inside `<ul><li>`, moved to `<div><div>`
2. added describedby hints
3. added aria-owns, role and aria-autocomplete to input
4. added aria-selected, role, aria-posinset, aria-setsize and id to result list items
5. added aria-live, to read selected, highlighted statuses and number of available options
6. added field value to aria-label. example aria-label="Currency (USD)"