### PR TITLE
fix chosen single select labels

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -744,16 +744,19 @@ class Chosen extends AbstractChosen
     input_field.val()
 
   set_label_attributes: () ->
-    associated_select_field = $('select[id="' + $(@container).attr('id').replace('_chosen', '') + '"]')
-    if aria_describedby = associated_select_field.attr('aria-describedby')
-      @search_field.attr 'aria-describedby', aria_describedby
+    if $(@container).attr('id')
+      associated_select_field = $('select[id="' + $(@container).attr('id').replace('_chosen', '') + '"]')
+      if aria_describedby = associated_select_field.attr('aria-describedby')
+        @search_field.attr 'aria-describedby', aria_describedby
 
-    if aria_labelledby = associated_select_field.attr('aria-labelledby')
-      @search_field.attr 'aria-labelledby', aria_labelledby
-    else if aria_label = associated_select_field.attr('aria-label')
-      @search_field.attr 'aria-label', aria_label
-    else if aria_label = $('label[for="' + associated_select_field.attr('id') + '"]')
-      @search_field.attr 'aria-label', aria_label.text()
+      if aria_labelledby = associated_select_field.attr('aria-labelledby')
+        @search_field.attr 'aria-labelledby', aria_labelledby
+      else if aria_label = associated_select_field.attr('aria-label')
+        @search_field.attr 'aria-label', aria_label
+      else if aria_label = $('label[for="' + associated_select_field.attr('id') + '"]')
+        @search_field.attr 'aria-label', aria_label.text()
+    else if label = $(@container).prevAll('label').first().text()
+      @search_field.attr('aria-label', label)
 
 tabCallback = (container) ->
   tabbable_element = null


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/CD-170887

original PR https://github.com/coupa/chosen/pull/9

- [x] @johnny-lai 
- [x] @curtismoore 

some chosen containers don't have `id` attribute, so we should find nearest `label`.

<img width="866" alt="Screenshot 2019-10-31 at 16 31 06" src="https://user-images.githubusercontent.com/2711162/67955875-e93d9100-fbfb-11e9-8037-1ca4293286d4.png">
