### PR TITLE
stop propagation for popup when dropdown is expanded and user press E…

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -662,6 +662,9 @@ class Chosen extends AbstractChosen
         evt.preventDefault()
         this.keydown_arrow()
         break
+      when 27
+        evt.preventDefault() if this.results_showing
+        break
 
   search_field_scale: ->
     if true #@is_multiple


### PR DESCRIPTION
- [x] @johnny-lai 

JIra Issue: https://coupadev.atlassian.net/browse/CD-171113

Summary: 
At "New Scheduled Report" popup, 'Recipients ' has list of options present as drop-down list. While interacting with keyboard, when the drop-down list is open, and for closing the same, if we press 'esc' key, entire popup is getting closed. And not only the 'Recipients ' drop-down list.

Changes: 
Stopping the propagation when the user press the ESC key