### PR TITLE
(master)CD-191229: remove divs with class 'is-scope' when clear results

### DIFF
--- a/coffee/chosen.jquery.coffee
+++ b/coffee/chosen.jquery.coffee
@@ -577,6 +577,7 @@ class Chosen extends AbstractChosen
 
   result_clear_scope: ->
     @scopes = []
+    @search_container.siblings("div.is-scope").remove()
     @search_container.siblings("li.is-scope").remove()
     
   result_scopes_build: ->


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/CD-191229

- [x] @johnny-lai 

container for `search-choice` was changed from `li` to `div` elements. 
https://github.com/coupa/chosen/commit/07c7a67a0951cc4ffc832ff31ae763fb10a26369#diff-c82fb80b20c6f4dcdec5a08a57059c30R244
```
  <div class=chosen-scopes>
  <div class=search-choice is-scope>
```
That is why we should update `result_clear_scope` method to remove `div.is-scope` elements. 
And we still have
```
  <ul class=chosen-scopes>
  <li class=is-scope>
```

inside `chosen-drop` container, so we should remove both `div.is-scope` and `li.is-scope`

  